### PR TITLE
Add option to graph results

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ statistical analysis on your typing performance with various setups.
 License
 =======
 
-Copyright 2017 Christian Stigen Larsen
+Copyright 2018 Christian Stigen Larsen
 
 Distributed under the GNU GPL v3 or later. See the file LICENSE.txt for the
 full license text. This software makes use of open source software.

--- a/wpm/__init__.py
+++ b/wpm/__init__.py
@@ -5,13 +5,13 @@
 Measures your typing speed in words per minute (WPM).
 
 This file is part of the wpm software.
-Copyright 2017 Christian Stigen Larsen
+Copyright 2018 Christian Stigen Larsen
 
 Distributed under the GNU GPL v3 or later. See the file LICENSE.txt for the
 full license text. This software makes use of open source software.
 """
 
 __author__ = "Christian Stigen Larsen"
-__copyright__ = "Copyright 2017 Christian Stigen Larsen"
+__copyright__ = "Copyright 2018 Christian Stigen Larsen"
 __license__ = "GNU GPL v3 or later"
 __version__ = "1.34"

--- a/wpm/__main__.py
+++ b/wpm/__main__.py
@@ -2,7 +2,7 @@
 
 """
 This file is part of the wpm software.
-Copyright 2017 Christian Stigen Larsen
+Copyright 2018 Christian Stigen Larsen
 
 Distributed under the GNU GPL v3 or later. See the file LICENSE.txt for the
 full license text. This software makes use of open source software.

--- a/wpm/commandline.py
+++ b/wpm/commandline.py
@@ -15,6 +15,7 @@ import sys
 import wpm
 import wpm.error
 import wpm.game
+import wpm.graph
 import wpm.quotes
 import wpm.stats
 
@@ -45,6 +46,9 @@ The format is
 
     p.add_argument("--stats-file", default="~/.wpm.csv", type=str,
             help="File to record score history to (CSV format)")
+
+    p.add_argument("-g", "--graph", default="~/.wpm.csv", type=str,
+            help="Plot wpm scores as a line graph")
 
     opts = p.parse_args()
 

--- a/wpm/commandline.py
+++ b/wpm/commandline.py
@@ -2,7 +2,7 @@
 
 """
 This file is part of the wpm software.
-Copyright 2017 Christian Stigen Larsen
+Copyright 2018 Christian Stigen Larsen
 
 Distributed under the GNU GPL v3 or later. See the file LICENSE.txt for the
 full license text. This software makes use of open source software.

--- a/wpm/game.py
+++ b/wpm/game.py
@@ -5,7 +5,7 @@
 Measures your typing speed in words per minute (WPM).
 
 This file is part of the wpm software.
-Copyright 2017 Christian Stigen Larsen
+Copyright 2018 Christian Stigen Larsen
 
 Distributed under the GNU GPL v3 or later. See the file LICENSE.txt for the
 full license text. This software makes use of open source software.

--- a/wpm/graph.py
+++ b/wpm/graph.py
@@ -1,0 +1,16 @@
+import pandas as pd
+import gnuplotlib as gp
+
+
+df = pd.read_csv('~/.wpm.csv')
+df.columns = ['race', 'wpm', 'Accuracy', 'Rank', 'Racers', 'text_id', 'Timestamp', 'Database', 'Keyboard']
+
+wpm = df['wpm']
+print wpm
+
+gp.plot( (wpm, {'legend': 'WPM'}),
+
+         title='WPM Graph',
+         _with='lines lc rgb "red"',
+         terminal='dumb 80,40',
+         unset='grid')

--- a/wpm/stats.py
+++ b/wpm/stats.py
@@ -2,7 +2,7 @@
 
 """
 This file is part of the wpm software.
-Copyright 2017 Christian Stigen Larsen
+Copyright 2018 Christian Stigen Larsen
 
 Distributed under the GNU GPL v3 or later. See the file LICENSE.txt for the
 full license text. This software makes use of open source software.


### PR DESCRIPTION
This is a PR that's not fully complete -- I had a little trouble getting the script to run from the `commandline.py` file.

### What This Does
I wanted to make an option to graph your wpm results in the terminal using command: `$ wpm --graph`
Currently, the `graph.py` file imports the default wpm data from `~/.wpm.csv`, labels the columns, creates a dataframe for the WPM column, and then creates a simple line graph from that data.
In the line graph, the **x-axis** is the index and the **y-axis** is the WPM.
I tried adding colors, but was unable to get it working with the terminal output.

### Tools
I looked into a few tools to graph directly in terminal and ended up getting a simple display working with [gnuplotlib](https://github.com/dkogan/gnuplotlib) and [pandas](https://github.com/pandas-dev/pandas) libraries.

### To-Do
- add color support
- label axis
- incorporate accuracy without skewing data

### Notes
There definitely can be more features added, but wanted to submit a PR to get the initial setup going (along with some help on getting it to work within wpm 😄)
Thoughts, comments, and help are greatly appreciated!

## Screenshot
Screenshot of the script in action. The WPM results column is being printed before the graph is generated.
![screen shot 2018-02-27 at 11 24 59 am](https://user-images.githubusercontent.com/3655354/36742091-cc1694a6-1bb4-11e8-8a7d-1b2cce3e0e7a.png)