### PR TITLE
[WIP] Change default location for config files to platform defined config folder (Close #42)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ GPATH
 GRTAGS
 GTAGS
 stats
+.mypy_cache/
+.vscode/

--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,7 @@ zero-based integer will be used.
 Format of race history
 ----------------------
 
-wpm will save scores in a CSV file in `~/.wpm.csv`. This file can be loaded
+wpm will save scores in a CSV file in `~/.config/wpm/wpm.csv`. This file can be loaded
 directly into Excel. It uses the same format as TypeRacer, with the addition of
 a few extra columns at the end. That means is should be possible to use
 existing TypeRacer score history tools with this file with minor modifications.
@@ -164,7 +164,7 @@ tag        str      A user supplied tag for that score (e.g., keyboard)
 ========== ======== =======================================================
 
 Should there be any problem saving or loading the score history, it will copy
-the existing file into `~/.wpm.csv.backup` and create a new one.
+the existing file into `~/.config/wpm/wpm.csv.backup` and create a new one.
 
 Tagging races
 -------------
@@ -185,10 +185,10 @@ grouped by each tag. It shows things like the average over time, along with
 confidence and prediction intervals. An item like `n-10` means "the last 10
 games".
 
-The ~/.wpmrc file
+The wpmrc file
 -----------------
 
-The first time you start wpm, it writes a `.wpmrc` file to your home directory.
+The first time you start wpm, it writes a `wpmrc` file to `~/.config/wpm/wpmrc`.
 It contains user settings that you can change. They are given in the table
 below.
 

--- a/wpm/commandline.py
+++ b/wpm/commandline.py
@@ -51,7 +51,7 @@ The format is
     argp.add_argument("--cpm", default=False, action="store_true",
                       help="Shows CPM instead of WPM in stats")
 
-    argp.add_argument("--stats-file", default="~/.wpm.csv", type=str,
+    argp.add_argument("--stats-file", default="~/.config/wpm/wpm.csv", type=str,
                       help="File to record score history to (CSV format)")
 
     argp.add_argument("--id", "-i", default=None, type=int,

--- a/wpm/config.py
+++ b/wpm/config.py
@@ -37,6 +37,12 @@ def int_tuple(s):
     except ValueError:
         raise ConfigError("Required format is (integer, integer): %s" % s)
 
+def get_config_directory():
+    xdg_config_home = os.getenv("XDG_CONFIG_HOME")
+    if xdg_config_home == "":
+        xdg_config_home = os.path.join(os.getenv("HOME"), ".config")
+    return os.path.join(xdg_config_home, "wpm")
+
 DEFAULTS = {
     "curses": {
         "escdelay": (str, 15, "Curses ESCDELAY"),
@@ -87,19 +93,21 @@ class SectionValues(object):
         try:
             return convert(value)
         except ConfigError as e:
-            raise ConfigError("Error in .wpmrc section %r option %r: %s" %
+            raise ConfigError("Error in wpmrc section %r option %r: %s" %
                     (self.section, name, e))
 
 
 class Config(object):
-    """Contains the user configuration, backed by the .wpmrc file."""
+    """Contains the user configuration, backed by the wpmrc file."""
     # pylint: disable=too-many-public-methods
 
     config = None
 
     def __init__(self):
         Config.config = configparser.ConfigParser()
-        self.filename = os.path.expanduser("~/.wpmrc")
+        config_directory = get_config_directory()
+        self.filename = os.path.join(config_directory, "wpmrc")
+        os.makedirs(config_directory, exist_ok=True)
 
         if os.path.isfile(self.filename):
             self.load()
@@ -113,19 +121,19 @@ class Config(object):
         """Verifies wpmrc values."""
         level = self.wpm.confidence_level
         if not (0 < level < 1):
-            raise ConfigError("The .wpmrc confidence level must be within [0, 1>")
+            raise ConfigError("The wpmrc confidence level must be within [0, 1>")
 
     def load(self):
-        """Loads ~/.wpmrc config settings."""
+        """Loads wpmrc config settings."""
         Config.config.read(self.filename)
 
     def save(self):
-        """Saves settings to ~/.wpmrc"""
+        """Saves settings to wpmrc"""
         with open(self.filename, "wt") as file_obj:
             Config.config.write(file_obj)
 
     def add_defaults(self):
-        """Adds missing sections and options to your ~/.wpmrc file."""
+        """Adds missing sections and options to your wpmrc file."""
         for section, values in sorted(DEFAULTS.items()):
             if not Config.config.has_section(section):
                 Config.config.add_section(section)

--- a/wpm/error.py
+++ b/wpm/error.py
@@ -16,5 +16,5 @@ class WpmError(RuntimeError):
     pass
 
 class ConfigError(WpmError):
-    """Incorrect .wpmrc option."""
+    """Incorrect wpmrc option."""
     pass

--- a/wpm/stats.py
+++ b/wpm/stats.py
@@ -16,6 +16,7 @@ import csv
 import datetime
 import math
 import os
+from .config import get_config_directory
 
 class Timestamp(object):
     """Methods for dealing with timestamps."""
@@ -200,7 +201,7 @@ class Stats(object):
         """Loads stats from a CSV file."""
 
         if filename is None:
-            filename = os.path.expanduser("~/.wpm.csv")
+            filename = os.path.join(get_config_directory(), "wpm.csv")
 
         games = collections.defaultdict(list)
         current_tag = None


### PR DESCRIPTION
This change makes wpm load and store config files to `~/.config/wpm` by default, specifically the `wpm.csv` and `wpmrc` files. It also removes the current functionality of loading config files from the home directory, but let me know if I should readd that functionality as a fallback if the `~/.config/wpm/*` files don't exist since this would be a breaking change otherwise.