### PR TITLE
Option to launch monochrome

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ runpypy:
 stats:
 	@PYTHONPATH=. $(PYTHON) wpm --stats
 
+monochrome:
+	@PYTHONPATH=. $(PYTHON) wpm --monochrome
+
 remove-prefixes:
 	PYTHONPATH=. $(PYTHON) tools/remove-prefixes.py
 

--- a/wpm/commandline.py
+++ b/wpm/commandline.py
@@ -65,6 +65,9 @@ The format is
     argp.add_argument("--short", default=False, action="store_true",
                       help="Starts wpm with short texts")
 
+    argp.add_argument("--monochrome", default=False, action="store_true",
+                      help="Starts wpm with monochrome colors")
+
     opts = argp.parse_args()
 
     if opts.version:
@@ -273,7 +276,7 @@ def main():
         sys.exit(1)
 
     try:
-        with wpm.game.GameManager(quotes, stats, opts.cpm) as gm:
+        with wpm.game.GameManager(quotes, stats, opts.cpm, opts.monochrome) as gm:
             try:
                 gm.run(to_front=text_ids)
                 gm.stats.save(opts.stats_file)

--- a/wpm/config.py
+++ b/wpm/config.py
@@ -71,6 +71,17 @@ DEFAULTS = {
         "score": (int_tuple, (curses.COLOR_YELLOW, curses.COLOR_RED), ""),
         "top_bar": (int_tuple, (curses.COLOR_CYAN, curses.COLOR_BLUE), ""),
     },
+
+    "monochromecolors": {
+        "author": (int_tuple, (curses.COLOR_WHITE, curses.COLOR_BLACK), ""),
+        "background": (int, curses.COLOR_BLACK, ""),
+        "correct": (int_tuple, (curses.COLOR_WHITE, curses.COLOR_BLACK), ""),
+        "incorrect": (int_tuple, (curses.COLOR_BLACK, curses.COLOR_WHITE), ""),
+        "prompt": (int_tuple, (curses.COLOR_WHITE, curses.COLOR_BLACK), ""),
+        "quote": (int_tuple, (curses.COLOR_WHITE, curses.COLOR_BLACK), ""),
+        "score": (int_tuple, (curses.COLOR_WHITE, curses.COLOR_BLACK), ""),
+        "top_bar": (int_tuple, (curses.COLOR_WHITE, curses.COLOR_BLACK), ""),
+    },
 }
 
 class SectionValues(object):

--- a/wpm/game.py
+++ b/wpm/game.py
@@ -23,7 +23,7 @@ from wpm.screen import Screen
 
 class GameManager(object):
     """The main game runner."""
-    def __init__(self, quotes, stats, cpm_flag):
+    def __init__(self, quotes, stats, cpm_flag, monochrome):
         self.config = Config()
         self.stats = stats
         self.cpm_flag = cpm_flag
@@ -42,7 +42,7 @@ class GameManager(object):
         self.num_quotes = len(quotes)
         self.quotes = quotes.random_iterator()
 
-        self.screen = Screen()
+        self.screen = Screen(monochrome)
         self.set_quote(self.quotes.next())
 
     def __enter__(self):

--- a/wpm/screen.py
+++ b/wpm/screen.py
@@ -36,8 +36,10 @@ class Screen(object):
     COLOR_QUOTE = 7
     COLOR_STATUS = 8
 
-    def __init__(self):
+    def __init__(self, monochrome):
         self.config = Config()
+
+        self.monochrome = monochrome
 
         # Make delay slower
         os.environ.setdefault("ESCDELAY", self.config.curses.escdelay)
@@ -152,7 +154,9 @@ class Screen(object):
         """Sets up curses color pairs."""
         hicolor = os.getenv("TERM").endswith("256color")
 
-        if hicolor:
+        if self.monochrome:
+            color = self.config.monochromecolors
+        elif hicolor:
             color = self.config.xterm256colors
         else:
             color = self.config.xtermcolors


### PR DESCRIPTION
I added a feature to use monochrome color (#41) 
Foreground is white, background is black. In case of an incorrect character the foreground and background colors are swapped.