### PR TITLE
Allow specifying a custom config file.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,12 +175,13 @@ grouped by each tag. It shows things like the average over time, along with
 confidence and prediction intervals. An item like `n-10` means "the last 10
 games".
 
-The ~/.wpmrc file
+The .wpmrc file
 -----------------
 
 The first time you start wpm, it writes a `.wpmrc` file to your home directory.
-It contains user settings that you can change. They are given in the table
-below.
+You can specify a custom config file location with the `--config-file=...`
+option. The `.wpmrc` file contains user settings that you can change. The user
+settings are given in the table below.
 
 ============== =========================== ======= =============================================================================
 Section        Name                        Default Description

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,24 @@
+import os
+import unittest
+
+import wpm.config
+
+
+class ConfigTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        wpm.config.Config.persist = False
+
+    def test_default_config_file_is_resolved_to_homedir(self):
+        config = wpm.config.Config()
+        self.assertEquals(config.filename, os.path.expanduser("~/.wpmrc"))
+
+    def test_custom_config_file_is_resolved_relative_to_workingdir(self):
+        custom_config = ".wpmrc"
+        config = wpm.config.Config(custom_config)
+        self.assertEquals(config.filename, os.path.abspath(custom_config))
+
+    def test_custom_config_file_with_user_path_is_resolved(self):
+        custom_config = "~/.config/wpm/wpmrc"
+        config = wpm.config.Config(custom_config)
+        self.assertEquals(config.filename, os.path.expanduser(custom_config))

--- a/wpm/commandline.py
+++ b/wpm/commandline.py
@@ -56,6 +56,9 @@ The format is
     argp.add_argument("--stats-file", default="~/.wpm.csv", type=str,
                       help="File to record score history to (CSV format)")
 
+    argp.add_argument("--config-file", default="~/.wpmrc", type=str,
+                      help="File to store configuration.")
+
     argp.add_argument("--id", "-i", default=None, type=int,
                       help="If specified, jumps to given text ID on start.")
 
@@ -239,7 +242,7 @@ def main():
     try:
         opts = parse_args()
 
-        config = wpm.config.Config()
+        config = wpm.config.Config(opts.config_file)
         if config.wpm.cpm:
             opts.cpm = True
 

--- a/wpm/config.py
+++ b/wpm/config.py
@@ -107,10 +107,11 @@ class Config(object):
     # pylint: disable=too-many-public-methods
 
     config = None
+    persist = True
 
-    def __init__(self):
+    def __init__(self, filename="~/.wpmrc"):
         Config.config = configparser.ConfigParser()
-        self.filename = os.path.expanduser("~/.wpmrc")
+        self.filename = os.path.abspath(os.path.expanduser(filename))
 
         if os.path.isfile(self.filename):
             self.load()
@@ -118,7 +119,8 @@ class Config(object):
             self.verify()
         else:
             self.add_defaults()
-            self.save()
+            if self.persist:
+                self.save()
 
     def verify(self):
         """Verifies wpmrc values."""
@@ -127,16 +129,16 @@ class Config(object):
             raise ConfigError("The .wpmrc confidence level must be within [0, 1>")
 
     def load(self):
-        """Loads ~/.wpmrc config settings."""
+        """Loads config settings."""
         Config.config.read(self.filename)
 
     def save(self):
-        """Saves settings to ~/.wpmrc"""
+        """Saves settings"""
         with open(self.filename, "wt") as file_obj:
             Config.config.write(file_obj)
 
     def add_defaults(self):
-        """Adds missing sections and options to your ~/.wpmrc file."""
+        """Adds missing sections and options to the config file."""
         for section, values in sorted(DEFAULTS.items()):
             if not Config.config.has_section(section):
                 Config.config.add_section(section)


### PR DESCRIPTION
Augments the Config class to accept an optional filename parameter to
specify a custom config file. Adds an argument to the CLI to pass the config
file through to the Config class.

Adds tests to ensure existing functionality is maintained, and paths are
expanded to abspaths properly.  Adds a class variable "persist" to the Config
class to prevent writing files to disk during testing.