### PR TITLE
Fix division by zero errors that occur when zero seconds have elapsed

### DIFF
--- a/wpm/game.py
+++ b/wpm/game.py
@@ -128,11 +128,15 @@ class GameManager(object):
         """Words per minute."""
         if self.start is None:
             return 0
+        elif not elapsed:
+            return 0
         return min((60.0 * self.position / 5.0) / elapsed, 999)
 
     def cps(self, elapsed):
         """Characters per second."""
         if self.start is None:
+            return 0
+        elif not elapsed:
             return 0
         return min(float(self.position) / elapsed, 99)
 


### PR DESCRIPTION
Running `wpm` often results in a crash as soon as you type a key, because the code for printing stats doesn't check for divisions by zero, when `elapsed=0`.

This code should clean this up. Thanks for this project, it's great to use on breaks from work or first thing in the morning.