### PR TITLE
add support for "start of header" key (ctrl-a)

### DIFF
--- a/wpm/game.py
+++ b/wpm/game.py
@@ -252,13 +252,18 @@ class GameManager(object):
 
         self.recorder.add(self.elapsed, key, self.position, self.incorrect)
 
+        if Screen.is_start_of_header(key):
+            self.position -= (len(self._edit) - self.incorrect)
+            self.incorrect = 0
+            self._edit = ""
+            return
+
         if Screen.is_backspace(key):
             if self.incorrect:
                 self.incorrect -= 1
-                self._edit = self._edit[:-1]
             elif self._edit:
                 self.position -= 1
-                self._edit = self._edit[:-1]
+            self._edit = self._edit[:-1]
             return
 
         if self.stop is not None:

--- a/wpm/screen.py
+++ b/wpm/screen.py
@@ -200,6 +200,13 @@ class Screen(object):
         return False
 
     @staticmethod
+    def is_start_of_header(key):
+        """Checks for start of header key."""
+        if len(key) == 1:
+            return ord(key) == curses.ascii.SOH
+        return False
+
+    @staticmethod
     def is_backspace(key):
         """Checks for backspace key."""
         if len(key) > 1:


### PR DESCRIPTION
mimics ctrl+a behavior in typeracer for retrying current word(s). Could be a viable solution for #59 