### PR TITLE
switch from pkg_resources to importlib

### DIFF
--- a/wpm/difficulty.py
+++ b/wpm/difficulty.py
@@ -11,7 +11,7 @@ The quotes database is *not* covered by the AGPL!
 import gzip
 import pickle
 
-import pkg_resources
+import importlib.resources
 
 class Difficulty(object):
     """Loads difficulty scores."""
@@ -19,8 +19,7 @@ class Difficulty(object):
     @staticmethod
     def _filename():
         """Returns the filename of the packaged difficulty database."""
-        return pkg_resources.resource_filename("wpm",
-                                               "data/difficulty.pickle.gz")
+        return importlib.resources.files("wpm").joinpath("data/difficulty.pickle.gz")
 
     @staticmethod
     def _normalize(diffs):

--- a/wpm/quotes.py
+++ b/wpm/quotes.py
@@ -20,7 +20,7 @@ import os
 import random
 import sys
 
-import pkg_resources
+import importlib.resources
 
 from wpm.error import WpmError
 
@@ -163,7 +163,7 @@ class Quotes(object):
     @staticmethod
     def _database_filename():
         """Returns the filename of the packaged database."""
-        return pkg_resources.resource_filename("wpm", "data/examples.json.gz")
+        return importlib.resources.files("wpm").joinpath("data/examples.json.gz")
 
     @staticmethod
     def load_json(filename=None):


### PR DESCRIPTION
pkg_resources is deprecated and is slated for removal as early as 2025-11-30. Use importlib.resources instead.
